### PR TITLE
feat: Initial project scaffold for CACM-ADK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to CACM-ADK
+
+We welcome contributions to the CACM Authoring & Development Kit!
+
+## How to Contribute
+
+-   **Reporting Bugs:** If you find a bug, please open an issue in the project's issue tracker, providing as much detail as possible.
+-   **Suggesting Enhancements:** For feature requests or enhancements, please open an issue to discuss your ideas.
+-   **Pull Requests:** We are happy to accept pull requests for bug fixes or approved features.
+    -   Please ensure your code follows any existing style guidelines (to be defined).
+    -   Include unit tests for any new functionality.
+    -   Update documentation as necessary.
+
+## Code of Conduct
+(To be defined - expected to follow general open-source community standards.)
+
+## Development Setup
+(To be added)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-# cacm-adk
-cacm-adk
+# CACM Authoring & Development Kit (CACM-ADK)
+
+## Overview
+
+The CACM-ADK is an intelligent development environment and toolset designed to assist users (credit analysts, domain experts, developers) in authoring standardized Credit Analysis Capability Modules (CACMs).
+
+A CACM is a declarative, machine-readable blueprint (ideally JSON-LD or YAML) that defines a specific credit analysis capability. It specifies:
+- *What* analysis is performed.
+- *What* data is needed.
+- *How* it can adapt (configurable parameters).
+- *What* results are produced.
+- *How* quality is ensured (validation rules).
+- It references *logical* compute capabilities rather than specific code implementations.
+
+This project aims to build the core infrastructure and software for the CACM-ADK, enabling modular, intelligent, and governed development of credit analysis capabilities. The system is designed to be portable, modular, lightweight, and deeply expert, potentially packaged as a microservice or REST API.
+
+## Project Goals
+
+-   Develop a core engine for CACM authoring, including components for ontology navigation, template management, workflow assistance, metric/factor advice, parameterization help, validation, modular design prompting, and documentation generation.
+-   Define a clear standard for CACM definitions.
+-   Develop a comprehensive credit analysis ontology.
+-   Build a library of CACM templates.
+-   Create an authoring and development kit (ADK) to guide the building process, train users, and improve over time.
+-   Ensure the system is scalable, future-proof, and can integrate with external services like LLMs, schema validators, and compute catalogs.
+
+## Repository Structure
+
+-   `cacm_adk_core/`: Source code for the core engine components.
+-   `cacm_library/`: Definitions of CACMs and reusable templates.
+-   `cacm_standard/`: The CACM definition standard/schema.
+-   `ontology/`: The credit analysis semantic ontology.
+-   `docs/`: Project documentation.
+-   `tests/`: Automated tests.
+-   `examples/`: Example CACMs and usage scenarios.
+-   `config/`: Configuration files.
+-   `scripts/`: Utility and automation scripts.
+-   `interfaces/`: API definitions and schemas.
+
+## Getting Started
+(To be added)
+
+## Contributing
+Please see `CONTRIBUTING.md`.

--- a/cacm_adk_core/__init__.py
+++ b/cacm_adk_core/__init__.py
@@ -1,0 +1,1 @@
+# This file marks cacm_adk_core as a Python package.

--- a/cacm_adk_core/doc_gen/__init__.py
+++ b/cacm_adk_core/doc_gen/__init__.py
@@ -1,0 +1,1 @@
+# This file marks doc_gen as a Python package.

--- a/cacm_adk_core/doc_gen/doc_gen.py
+++ b/cacm_adk_core/doc_gen/doc_gen.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/doc_gen/doc_gen.py
+
+class DocGen:
+    """
+    Generates various documentation artifacts based on the authored CACM
+    content, using predefined or custom templates.
+    """
+    def __init__(self):
+        pass
+
+    def generate_document(self, content: dict, template_name: str):
+        """
+        Generates a document from content using a specific template.
+        """
+        print(f"Generating document using template '{template_name}' with content: {content}")
+        # Placeholder for actual document generation
+        return f"Generated document for {template_name}"
+
+if __name__ == '__main__':
+    doc_generator = DocGen()
+    document = doc_generator.generate_document({"title": "Model Overview"}, "standard_overview_v1")
+    print(document)

--- a/cacm_adk_core/metric_advisor/__init__.py
+++ b/cacm_adk_core/metric_advisor/__init__.py
@@ -1,0 +1,1 @@
+# This file marks metric_advisor as a Python package.

--- a/cacm_adk_core/metric_advisor/metric_advisor.py
+++ b/cacm_adk_core/metric_advisor/metric_advisor.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/metric_advisor/metric_advisor.py
+
+class MetricAdvisor:
+    """
+    Suggests relevant metrics for evaluating a given model or component
+    based on its type and the user's goals.
+    """
+    def __init__(self):
+        pass
+
+    def suggest_metrics(self, model_type: str, goals: list):
+        """
+        Suggests metrics based on model type and goals.
+        """
+        print(f"Suggesting metrics for model type '{model_type}' with goals: {goals}")
+        # Placeholder for actual metric suggestion logic
+        return ["Accuracy", "Precision", "Recall"]
+
+if __name__ == '__main__':
+    advisor = MetricAdvisor()
+    metrics = advisor.suggest_metrics("Classification", ["High Accuracy", "Low False Positives"])
+    print(f"Suggested metrics: {metrics}")

--- a/cacm_adk_core/modular_prompter/__init__.py
+++ b/cacm_adk_core/modular_prompter/__init__.py
@@ -1,0 +1,1 @@
+# This file marks modular_prompter as a Python package.

--- a/cacm_adk_core/modular_prompter/modular_prompter.py
+++ b/cacm_adk_core/modular_prompter/modular_prompter.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/modular_prompter/modular_prompter.py
+
+class ModularPrompter:
+    """
+    Constructs and manages prompts for interacting with LLMs,
+    potentially using a library of prompt components.
+    """
+    def __init__(self):
+        pass
+
+    def generate_prompt(self, task_description: str, context: dict):
+        """
+        Generates a tailored prompt for a given task and context.
+        """
+        print(f"Generating prompt for task: {task_description} with context: {context}")
+        # Placeholder for actual prompt generation
+        return f"Prompt for {task_description}"
+
+if __name__ == '__main__':
+    prompter = ModularPrompter()
+    prompt = prompter.generate_prompt("Generate model description", {"model_type": "Decision Tree"})
+    print(prompt)

--- a/cacm_adk_core/ontology_navigator/__init__.py
+++ b/cacm_adk_core/ontology_navigator/__init__.py
@@ -1,0 +1,1 @@
+# This file marks ontology_navigator as a Python package.

--- a/cacm_adk_core/ontology_navigator/ontology_navigator.py
+++ b/cacm_adk_core/ontology_navigator/ontology_navigator.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/ontology_navigator/ontology_navigator.py
+
+class OntologyNavigator:
+    """
+    Helps users browse, search, and select relevant concepts from the
+    domain ontology.
+    """
+    def __init__(self):
+        pass
+
+    def find_concepts(self, keyword: str):
+        """
+        Finds concepts in the ontology matching the keyword.
+        """
+        print(f"Searching for concepts related to: {keyword}")
+        # Placeholder for actual ontology interaction
+        return []
+
+if __name__ == '__main__':
+    navigator = OntologyNavigator()
+    concepts = navigator.find_concepts("credit risk")
+    print(f"Found concepts: {concepts}")

--- a/cacm_adk_core/orchestrator/__init__.py
+++ b/cacm_adk_core/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+# This file marks orchestrator as a Python package.

--- a/cacm_adk_core/orchestrator/orchestrator.py
+++ b/cacm_adk_core/orchestrator/orchestrator.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/orchestrator/orchestrator.py
+
+class Orchestrator:
+    """
+    Manages the overall process of CACM authoring, interacting with other
+    core components and external services.
+    """
+    def __init__(self):
+        pass
+
+    def start_authoring_session(self, user_goal: str):
+        """
+        Initiates a new CACM authoring session based on a high-level user goal.
+        """
+        print(f"Starting authoring session for goal: {user_goal}")
+        # Further logic will involve other components
+        pass
+
+if __name__ == '__main__':
+    # Example usage (optional, for early testing)
+    orchestrator = Orchestrator()
+    orchestrator.start_authoring_session("Define a new credit scoring model for SMEs.")

--- a/cacm_adk_core/param_helper/__init__.py
+++ b/cacm_adk_core/param_helper/__init__.py
@@ -1,0 +1,1 @@
+# This file marks param_helper as a Python package.

--- a/cacm_adk_core/param_helper/param_helper.py
+++ b/cacm_adk_core/param_helper/param_helper.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/param_helper/param_helper.py
+
+class ParamHelper:
+    """
+    Assists in defining, validating, and suggesting parameters for
+    model components or other configurable elements.
+    """
+    def __init__(self):
+        pass
+
+    def get_param_recommendations(self, component_type: str):
+        """
+        Provides recommended parameters for a given component type.
+        """
+        print(f"Getting parameter recommendations for: {component_type}")
+        # Placeholder for actual recommendation logic
+        return {"learning_rate": 0.01, "epochs": 100}
+
+if __name__ == '__main__':
+    helper = ParamHelper()
+    params = helper.get_param_recommendations("NeuralNetwork")
+    print(f"Recommended params: {params}")

--- a/cacm_adk_core/template_engine/__init__.py
+++ b/cacm_adk_core/template_engine/__init__.py
@@ -1,0 +1,1 @@
+# This file marks template_engine as a Python package.

--- a/cacm_adk_core/template_engine/template_engine.py
+++ b/cacm_adk_core/template_engine/template_engine.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/template_engine/template_engine.py
+
+class TemplateEngine:
+    """
+    Manages and populates predefined templates for various CACM artifacts
+    (e.g., model specifications, documentation sections).
+    """
+    def __init__(self):
+        pass
+
+    def populate_template(self, template_name: str, data: dict):
+        """
+        Populates a given template with provided data.
+        """
+        print(f"Populating template '{template_name}' with data: {data}")
+        # Placeholder for actual template processing
+        return f"Content of {template_name} with {data}"
+
+if __name__ == '__main__':
+    engine = TemplateEngine()
+    populated_doc = engine.populate_template("model_spec_v1", {"model_type": "Linear Regression"})
+    print(populated_doc)

--- a/cacm_adk_core/validator/__init__.py
+++ b/cacm_adk_core/validator/__init__.py
@@ -1,0 +1,1 @@
+# This file marks validator as a Python package.

--- a/cacm_adk_core/validator/validator.py
+++ b/cacm_adk_core/validator/validator.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/validator/validator.py
+
+class Validator:
+    """
+    Performs validation checks on CACM artifacts, ensuring consistency,
+    completeness, and adherence to predefined rules or schemas.
+    """
+    def __init__(self):
+        pass
+
+    def validate_artifact(self, artifact_path: str, schema_type: str):
+        """
+        Validates a given artifact against a schema or ruleset.
+        """
+        print(f"Validating artifact '{artifact_path}' against schema '{schema_type}'")
+        # Placeholder for actual validation logic
+        return True # Assuming validation passes
+
+if __name__ == '__main__':
+    validator = Validator()
+    is_valid = validator.validate_artifact("path/to/model_spec.json", "ModelSpecSchemaV2")
+    print(f"Artifact is valid: {is_valid}")

--- a/cacm_adk_core/workflow_assistant/__init__.py
+++ b/cacm_adk_core/workflow_assistant/__init__.py
@@ -1,0 +1,1 @@
+# This file marks workflow_assistant as a Python package.

--- a/cacm_adk_core/workflow_assistant/workflow_assistant.py
+++ b/cacm_adk_core/workflow_assistant/workflow_assistant.py
@@ -1,0 +1,22 @@
+# cacm_adk_core/workflow_assistant/workflow_assistant.py
+
+class WorkflowAssistant:
+    """
+    Guides the user through predefined or custom authoring workflows,
+    suggesting next steps and actions.
+    """
+    def __init__(self):
+        pass
+
+    def get_next_step(self, current_context: dict):
+        """
+        Determines the next logical step in the authoring workflow.
+        """
+        print(f"Getting next step based on context: {current_context}")
+        # Placeholder for workflow logic
+        return "Define model components"
+
+if __name__ == '__main__':
+    assistant = WorkflowAssistant()
+    next_step = assistant.get_next_step({"current_stage": "ontology_selection"})
+    print(f"Next step: {next_step}")

--- a/cacm_library/templates/basic_ratio_analysis_template.jsonc
+++ b/cacm_library/templates/basic_ratio_analysis_template.jsonc
@@ -1,0 +1,73 @@
+// CACM Template: Basic Ratio Analysis
+// Version: 0.1.0
+// Description: A starting template for a CACM that performs basic financial ratio analysis.
+{
+  // "$schema": "../../cacm_standard/cacm_schema_v0.1.json", // Optional: points to the schema for validation and IDE support
+  "cacmId": "urn:uuid:generate-new-uuid", // Placeholder: A new UUID should be generated when this template is instantiated
+  "version": "0.1.0-template",
+  "name": "Basic Financial Ratio Analysis",
+  "description": "Calculates fundamental financial ratios (e.g., Current Ratio, Debt-to-Equity) based on provided financial statements.",
+  "metadata": {
+    "author": "CACM Template Library",
+    "creationDate": "2023-10-27T10:00:00Z", // Should be updated on instantiation
+    "tags": ["financial_ratio", "template", "sme_lending"],
+    "templateDetails": {
+      "templateName": "Basic Ratio Analysis",
+      "templateVersion": "0.1.0",
+      "intendedUsage": "As a starting point for common ratio calculations. Customize input/output schemas and specific ratios as needed."
+    }
+  },
+  "inputs": {
+    // Placeholder: Define input schema, e.g., referencing concepts from the ontology
+    // "financialStatement": {
+    //   "type": "object",
+    //   "properties": {
+    //     "currentAssets": { "type": "number", "description": "Total Current Assets" },
+    //     "currentLiabilities": { "type": "number", "description": "Total Current Liabilities" }
+    //   },
+    //  "required": ["currentAssets", "currentLiabilities"]
+    // }
+  },
+  "outputs": {
+    // Placeholder: Define output schema
+    // "ratios": {
+    //   "type": "object",
+    //   "properties": {
+    //     "currentRatio": { "type": "number", "description": "Current Assets / Current Liabilities" }
+    //   }
+    // }
+  },
+  "workflow": {
+    "steps": [
+      // Placeholder: Define logical workflow steps
+      // {
+      //   "stepId": "calculate_current_ratio",
+      //   "description": "Calculate the Current Ratio",
+      //   "computeCapability": "compute:CalculateRatio", // Logical capability reference
+      //   "parameters": {
+      //     "numerator": "inputs.financialStatement.currentAssets",
+      //     "denominator": "inputs.financialStatement.currentLiabilities"
+      //   },
+      //   "outputs": ["outputs.ratios.currentRatio"]
+      // }
+    ]
+  },
+  "parameters": [
+    // Placeholder: Define configurable parameters for this CACM
+    // {
+    //   "paramId": "roundingPrecision",
+    //   "name": "Rounding Precision",
+    //   "description": "Number of decimal places for calculated ratios.",
+    //   "type": "integer",
+    //   "defaultValue": 2
+    // }
+  ],
+  "validationRules": [
+    // Placeholder: Define validation rules for inputs, outputs, or parameters
+    // {
+    //   "ruleId": "current_assets_positive",
+    //   "description": "Current Assets must be a positive number.",
+    //   "expression": "inputs.financialStatement.currentAssets > 0"
+    // }
+  ]
+}

--- a/cacm_standard/cacm_schema_v0.1.json
+++ b/cacm_standard/cacm_schema_v0.1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CACM Definition",
+  "description": "A preliminary schema for a Credit Analysis Capability Module (CACM). Version 0.1 (Initial Draft)",
+  "type": "object",
+  "properties": {
+    "cacmId": {
+      "description": "Unique identifier for the CACM.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "version": {
+      "description": "Version of this CACM definition.",
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "name": {
+      "description": "Human-readable name for the CACM.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A brief description of what the CACM does.",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "author": { "type": "string" },
+        "creationDate": { "type": "string", "format": "date-time" },
+        "lastModifiedDate": { "type": "string", "format": "date-time" },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["creationDate"]
+    }
+  },
+  "required": [
+    "cacmId",
+    "version",
+    "name",
+    "description"
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,25 @@
+# CACM-ADK System Architecture
+
+## High-Level Overview
+
+(This document will detail the architecture of the CACM-ADK system, including its components, their interactions, and how it fits into a larger enterprise ecosystem for credit analysis.)
+
+Key components to be detailed:
+-   User Interaction Layer (Agent/IDE/Web)
+-   CACM-ADK Core Engine
+    -   Orchestrator
+    -   Ontology Navigator & Expert
+    -   Template Engine
+    -   Workflow Assistant
+    -   Metric & Factor Advisor
+    -   Parameterization Helper
+    -   Semantic & Structural Validator
+    -   Modular Design Prompter
+    -   Documentation Generator
+-   External Dependencies & Services (LLM, Ontology Store, Template Repo, etc.)
+
+## Data Flows
+(Details on how data, CACM definitions, and control signals flow through the system.)
+
+## Deployment Model
+(Considerations for deploying the CACM-ADK, e.g., as a microservice.)

--- a/ontology/credit_analysis_ontology_v0.1/credit_ontology.ttl
+++ b/ontology/credit_analysis_ontology_v0.1/credit_ontology.ttl
@@ -1,0 +1,28 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cacm_ont: <http://example.com/ontology/cacm_credit_ontology/0.1#> .
+
+# Base URI for this ontology
+<http://example.com/ontology/cacm_credit_ontology/0.1>
+    a owl:Ontology ;
+    rdfs:label "Credit Analysis Capability Module Ontology (CACM-Ont)" ;
+    rdfs:comment "Preliminary ontology for defining terms, concepts, and relationships in the domain of credit analysis for CACMs. Version 0.1 (Initial Draft)" ;
+    owl:versionInfo "0.1.0" .
+
+# Example Class
+cacm_ont:CreditActivity
+    a rdfs:Class, owl:Class ;
+    rdfs:label "Credit Activity"@en ;
+    rdfs:comment "A general concept representing any activity or process related to credit analysis."@en ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+
+# Example Property
+cacm_ont:hasInputParameter
+    a rdf:Property, owl:ObjectProperty ; # Assuming it links to a parameter definition, could be DatatypeProperty too
+    rdfs:label "has input parameter"@en ;
+    rdfs:comment "Relates a CACM or a step within it to an input parameter it requires."@en ;
+    rdfs:domain cacm_ont:CreditActivity ; # Example domain
+    # rdfs:range cacm_ont:Parameter ; # Example range (Parameter class would need to be defined)
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file marks tests as a Python package.

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,0 +1,1 @@
+# This file marks tests/core as a Python package.

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -1,0 +1,22 @@
+# tests/core/test_orchestrator.py
+import unittest
+# Attempt to import the component, handle if it's not perfectly on PYTHONPATH yet for scaffolding
+try:
+    from cacm_adk_core.orchestrator.orchestrator import Orchestrator
+except ImportError:
+    Orchestrator = None # Placeholder if import fails during early scaffolding
+
+class TestOrchestrator(unittest.TestCase):
+
+    def test_orchestrator_initialization(self):
+        if Orchestrator:
+            orchestrator = Orchestrator()
+            self.assertIsNotNone(orchestrator, "Orchestrator should be initializable")
+        else:
+            self.skipTest("Skipping test: Orchestrator component not found or import error.")
+
+    def test_placeholder(self):
+        self.assertTrue(True, "Placeholder test, to be replaced.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/test_template_engine.py
+++ b/tests/core/test_template_engine.py
@@ -1,0 +1,21 @@
+# tests/core/test_template_engine.py
+import unittest
+try:
+    from cacm_adk_core.template_engine.template_engine import TemplateEngine
+except ImportError:
+    TemplateEngine = None
+
+class TestTemplateEngine(unittest.TestCase):
+
+    def test_template_engine_initialization(self):
+        if TemplateEngine:
+            engine = TemplateEngine()
+            self.assertIsNotNone(engine, "TemplateEngine should be initializable")
+        else:
+            self.skipTest("Skipping test: TemplateEngine component not found or import error.")
+
+    def test_placeholder(self):
+        self.assertTrue(True, "Placeholder test, to be replaced.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/test_validator.py
+++ b/tests/core/test_validator.py
@@ -1,0 +1,21 @@
+# tests/core/test_validator.py
+import unittest
+try:
+    from cacm_adk_core.validator.validator import Validator
+except ImportError:
+    Validator = None
+
+class TestValidator(unittest.TestCase):
+
+    def test_validator_initialization(self):
+        if Validator:
+            validator = Validator()
+            self.assertIsNotNone(validator, "Validator should be initializable")
+        else:
+            self.skipTest("Skipping test: Validator component not found or import error.")
+
+    def test_placeholder(self):
+        self.assertTrue(True, "Placeholder test, to be replaced.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I've set up the foundational directory structure and placeholder files for the Credit Analysis Capability Module Authoring & Development Kit (CACM-ADK).

This includes:
- Top-level directories for core components, library, ontology, docs, tests, examples, config, scripts, and interfaces.
- Placeholder Python classes for each component in the CACM-ADK core engine (Orchestrator, Validator, etc.).
- An initial draft for the CACM JSON schema (`cacm_schema_v0.1.json`).
- A placeholder for the credit analysis ontology (`credit_ontology.ttl`).
- An example CACM template (`basic_ratio_analysis_template.jsonc`).
- Basic documentation: README.md, CONTRIBUTING.md, and docs/architecture.md.
- An initial test structure with placeholder test files for core components.

This scaffold provides a comprehensive starting point for the iterative development of the CACM-ADK system, aligning with the vision for a modular, extensible, and well-documented platform.