### PR TITLE
feat: Create credit_ontology_v0.3.ttl

### DIFF
--- a/ontology/credit_analysis_ontology_v0.1/credit_ontology.ttl
+++ b/ontology/credit_analysis_ontology_v0.1/credit_ontology.ttl
@@ -2,27 +2,23 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix cacm_ont: <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-@prefix kgclass: <http://example.com/ontology/cacm_credit_ontology/0.3/classes/#> .
-@prefix kgprop: <http://example.com/ontology/cacm_credit_ontology/0.3/properties/#> .
+@prefix cacm_ont: <http://example.com/ontology/cacm_credit_ontology/0.1#> .
+@prefix kgclass: <http://example.org/kg/class/> .
+@prefix kgprop: <http://example.org/kg/property/> .
 
 # Base URI for this ontology
-<http://example.com/ontology/cacm_credit_ontology/0.3#>
+<http://example.com/ontology/cacm_credit_ontology/0.1>
     a owl:Ontology ;
-    dcterms:creator "Your Name or Organization" ; 
     rdfs:label "Credit Analysis Capability Module Ontology (CACM-Ont)" ;
-    owl:versionInfo "0.3.0"^^xsd:string ;
-    dcterms:modified "2024-07-11"^^xsd:date ;
-    dcterms:description "Comprehensive expansion of the credit analysis ontology, incorporating detailed terms for valuation, risk management, macroeconomics, technical analysis, ESG factors, and LLM/ADK components based on user-provided knowledge graph structure."^^xsd:string .
-
+    rdfs:comment "Preliminary ontology for defining terms, concepts, and relationships in the domain of credit analysis for CACMs. Version 0.1 (Initial Draft)" ;
+    owl:versionInfo "0.1.0" .
 
 # Example Class
 cacm_ont:CreditActivity
     a rdfs:Class, owl:Class ;
     rdfs:label "Credit Activity"@en ;
     rdfs:comment "A general concept representing any activity or process related to credit analysis."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # Example Property
 cacm_ont:hasInputParameter
@@ -31,7 +27,7 @@ cacm_ont:hasInputParameter
     rdfs:comment "Relates a CACM or a step within it to an input parameter it requires."@en ;
     rdfs:domain cacm_ont:CreditActivity ; # Example domain
     # rdfs:range cacm_ont:Parameter ; # Example range (Parameter class would need to be defined)
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # --- Core Concepts (Classes) ---
 
@@ -39,52 +35,52 @@ cacm_ont:FinancialInstrument
     a rdfs:Class, owl:Class ;
     rdfs:label "Financial Instrument"@en ;
     rdfs:comment "A financial instrument, such as a loan, bond, or line of credit, relevant to credit analysis."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:FinancialStatement
     a rdfs:Class, owl:Class ;
     rdfs:label "Financial Statement"@en ;
     rdfs:comment "A formal record of the financial activities and position of a business, person, or other entity (e.g., balance sheet, income statement)."@en ;
     rdfs:subClassOf cacm_ont:DataInput ; # Example of subclassing
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:Metric
     a rdfs:Class, owl:Class ;
     rdfs:label "Metric"@en ;
     rdfs:comment "A quantifiable measure used to track and assess the status of a specific business process, financial characteristic, or risk exposure."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:Ratio
     a rdfs:Class, owl:Class ;
     rdfs:label "Ratio"@en ;
     rdfs:comment "A type of metric that represents the relationship between two numbers or quantities, often used in financial analysis."@en ;
     rdfs:subClassOf cacm_ont:Metric ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:RiskScore
     a rdfs:Class, owl:Class ;
     rdfs:label "Risk Score"@en ;
     rdfs:comment "A numerical representation of the creditworthiness or risk associated with an entity or financial instrument."@en ;
     rdfs:subClassOf cacm_ont:Metric ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:EligibilityRule
     a rdfs:Class, owl:Class ;
     rdfs:label "Eligibility Rule"@en ;
     rdfs:comment "A specific criterion or condition that must be met for a credit application or process to proceed or be approved."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:DataInput # Renamed from DataInputSource for broader applicability
     a rdfs:Class, owl:Class ;
     rdfs:label "Data Input"@en ;
     rdfs:comment "Represents any piece of data or information used as an input for a credit analysis capability."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:Policy
     a rdfs:Class, owl:Class ;
     rdfs:label "Policy"@en ;
     rdfs:comment "A guiding principle or rule, often related to regulations or internal credit policies, that influences credit decisions."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # --- Core Properties (Relationships) ---
 
@@ -94,7 +90,7 @@ cacm_ont:hasDataSource
     rdfs:comment "Relates an entity (e.g., a Metric) to the source of its underlying data (e.g., a specific FinancialStatement or external DataInput)."@en ;
     # rdfs:domain could be cacm_ont:Metric or other relevant classes
     # rdfs:range cacm_ont:DataInput ; # Or a more specific data source type
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:calculatesMetric
     a rdf:Property, owl:ObjectProperty ;
@@ -102,7 +98,7 @@ cacm_ont:calculatesMetric
     rdfs:comment "Relates a process or capability to a metric it computes."@en ;
     # rdfs:domain cacm_ont:CreditActivity ; # Or a more specific capability class
     rdfs:range cacm_ont:Metric ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:appliesRule
     a rdf:Property, owl:ObjectProperty ;
@@ -110,7 +106,7 @@ cacm_ont:appliesRule
     rdfs:comment "Relates a process or capability to an eligibility rule or policy it enforces/checks."@en ;
     # rdfs:domain cacm_ont:CreditActivity ;
     rdfs:range cacm_ont:EligibilityRule ; # Or cacm_ont:Policy
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:requiresInput
     a rdf:Property, owl:ObjectProperty ;
@@ -118,7 +114,7 @@ cacm_ont:requiresInput
     rdfs:comment "Specifies that a capability, metric, or rule requires a particular type of data input."@en ;
     # rdfs:domain [ owl:unionOf ( cacm_ont:CreditActivity cacm_ont:Metric cacm_ont:EligibilityRule ) ] ; # Example complex domain
     rdfs:range cacm_ont:DataInput ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 cacm_ont:producesOutput
     a rdf:Property, owl:ObjectProperty ;
@@ -126,62 +122,62 @@ cacm_ont:producesOutput
     rdfs:comment "Specifies that a capability or step produces a particular type of data as output."@en ;
     # rdfs:domain cacm_ont:CreditActivity;
     # rdfs:range cacm_ont:DataInput; # Outputs can also be considered data inputs for subsequent processes
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # --- Expanded Concepts (Classes) based on User Feedback ---
 
 # Financial Statement Items (More Granular)
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#BalanceSheetItem> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Balance Sheet Item" ; rdfs:comment "An item typically found on a balance sheet statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#IncomeStatementItem> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Income Statement Item" ; rdfs:comment "An item typically found on an income statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CashFlowItem> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Cash Flow Item" ; rdfs:comment "An item typically found on a cash flow statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+kgclass:BalanceSheetItem rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Balance Sheet Item" ; rdfs:comment "An item typically found on a balance sheet statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:IncomeStatementItem rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Income Statement Item" ; rdfs:comment "An item typically found on an income statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:CashFlowItem rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Cash Flow Item" ; rdfs:comment "An item typically found on a cash flow statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # Valuation Concepts
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod> rdf:type owl:Class ; rdfs:label "Valuation Method" ; rdfs:comment "A method used to determine the economic worth of an asset or company." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#IntrinsicValuationMethod> rdf:type owl:Class ; rdfs:subClassOf <http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod> ; rdfs:label "Intrinsic Valuation Method" ; rdfs:comment "Valuation based on intrinsic characteristics, like DCF." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#RelativeValuationMethod> rdf:type owl:Class ; rdfs:subClassOf <http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod> ; rdfs:label "Relative Valuation Method" ; rdfs:comment "Valuation based on comparison with similar assets/companies (multiples)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CalculatedValue> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Calculated Value" ; rdfs:comment "A value derived from a calculation, often in valuation contexts (e.g., Present Value, EV)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationOutput> rdf:type owl:Class ; rdfs:label "Valuation Output" ; rdfs:comment "A specific output from a valuation process (e.g., Enterprise Value, Implied Share Price)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+kgclass:ValuationMethod rdf:type owl:Class ; rdfs:label "Valuation Method" ; rdfs:comment "A method used to determine the economic worth of an asset or company." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:IntrinsicValuationMethod rdf:type owl:Class ; rdfs:subClassOf kgclass:ValuationMethod ; rdfs:label "Intrinsic Valuation Method" ; rdfs:comment "Valuation based on intrinsic characteristics, like DCF." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:RelativeValuationMethod rdf:type owl:Class ; rdfs:subClassOf kgclass:ValuationMethod ; rdfs:label "Relative Valuation Method" ; rdfs:comment "Valuation based on comparison with similar assets/companies (multiples)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:CalculatedValue rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Calculated Value" ; rdfs:comment "A value derived from a calculation, often in valuation contexts (e.g., Present Value, EV)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:ValuationOutput rdf:type owl:Class ; rdfs:label "Valuation Output" ; rdfs:comment "A specific output from a valuation process (e.g., Enterprise Value, Implied Share Price)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # Risk Concepts (More Granular)
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#RiskCategory> rdf:type owl:Class ; rdfs:label "Risk Category" ; rdfs:comment "A classification for different types of risks (e.g., Credit Risk, Market Risk, Liquidity Risk)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CreditRiskMetric> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Credit Risk Metric" ; rdfs:comment "A metric specifically used to quantify or assess credit risk (e.g., PD, LGD, Expected Loss)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#LiquidityRiskType> rdf:type owl:Class ; rdfs:subClassOf <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RiskCategory> ; rdfs:label "Liquidity Risk Type" ; rdfs:comment "Specific types of liquidity risk, like Funding Liquidity Risk or Market Liquidity Risk." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+kgclass:RiskCategory rdf:type owl:Class ; rdfs:label "Risk Category" ; rdfs:comment "A classification for different types of risks (e.g., Credit Risk, Market Risk, Liquidity Risk)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:CreditRiskMetric rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Credit Risk Metric" ; rdfs:comment "A metric specifically used to quantify or assess credit risk (e.g., PD, LGD, Expected Loss)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:LiquidityRiskType rdf:type owl:Class ; rdfs:subClassOf kgclass:RiskCategory ; rdfs:label "Liquidity Risk Type" ; rdfs:comment "Specific types of liquidity risk, like Funding Liquidity Risk or Market Liquidity Risk." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # Financial Ratios (More Granular)
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#LeverageRatio> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Leverage Ratio" ; rdfs:comment "A financial ratio that measures the extent of a company's debt." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#LiquidityRatio> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Liquidity Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to meet short-term obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CoverageRatio> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Coverage Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to service its debt and other obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+kgclass:LeverageRatio rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Leverage Ratio" ; rdfs:comment "A financial ratio that measures the extent of a company's debt." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:LiquidityRatio rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Liquidity Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to meet short-term obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:CoverageRatio rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Coverage Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to service its debt and other obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # Regulatory & Policy Concepts
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#RegulatoryRating> rdf:type owl:Class ; rdfs:label "Regulatory Rating" ; rdfs:comment "A credit-related rating assigned based on regulatory frameworks (e.g., SNC categories)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#PolicyObjective> rdf:type owl:Class ; rdfs:label "Policy Objective" ; rdfs:comment "A stated goal or aim of a policy that might influence credit (e.g. inflation target)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+kgclass:RegulatoryRating rdf:type owl:Class ; rdfs:label "Regulatory Rating" ; rdfs:comment "A credit-related rating assigned based on regulatory frameworks (e.g., SNC categories)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:PolicyObjective rdf:type owl:Class ; rdfs:label "Policy Objective" ; rdfs:comment "A stated goal or aim of a policy that might influence credit (e.g. inflation target)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 # General Analysis Concepts
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#Assumption> rdf:type owl:Class ; rdfs:label "Assumption" ; rdfs:comment "An underlying assumption made during an analysis or forecast." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#Rationale> rdf:type owl:Class ; rdfs:label "Rationale" ; rdfs:comment "The reasoning or justification behind an analysis, conclusion, or rating." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#TrendIndicator> rdf:type owl:Class ; rdfs:label "Trend Indicator" ; rdfs:comment "An indicator used to determine the direction or strength of a trend." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-<http://example.com/ontology/cacm_credit_ontology/0.3/classes#MarketFactor> rdf:type owl:Class ; rdfs:label "Market Factor" ; rdfs:comment "An external market factor that can influence financial analysis or entities." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+kgclass:Assumption rdf:type owl:Class ; rdfs:label "Assumption" ; rdfs:comment "An underlying assumption made during an analysis or forecast." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:Rationale rdf:type owl:Class ; rdfs:label "Rationale" ; rdfs:comment "The reasoning or justification behind an analysis, conclusion, or rating." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:TrendIndicator rdf:type owl:Class ; rdfs:label "Trend Indicator" ; rdfs:comment "An indicator used to determine the direction or strength of a trend." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+kgclass:MarketFactor rdf:type owl:Class ; rdfs:label "Market Factor" ; rdfs:comment "An external market factor that can influence financial analysis or entities." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 
 
 # --- Expanded Properties (Relationships) based on User Feedback ---
 
-<http://example.com/ontology/cacm_credit_ontology/0.3/properties#calculatedFrom> rdf:type owl:ObjectProperty ; rdfs:label "calculated from" ; rdfs:comment "Indicates that a metric or value is derived from specific inputs or other metrics." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-# (domain: cacm_ont:Metric, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#CalculatedValue>; range: cacm_ont:DataInput, cacm_ont:Metric)
+kgprop:calculatedFrom rdf:type owl:ObjectProperty ; rdfs:label "calculated from" ; rdfs:comment "Indicates that a metric or value is derived from specific inputs or other metrics." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+# (domain: cacm_ont:Metric, kgclass:CalculatedValue; range: cacm_ont:DataInput, cacm_ont:Metric)
 
-<http://example.com/ontology/cacm_credit_ontology/0.3/properties#assessesRisk> rdf:type owl:ObjectProperty ; rdfs:label "assesses risk" ; rdfs:comment "Relates an analysis or metric to a specific type of risk it evaluates." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-# (domain: cacm:CreditAnalysisCapabilityModule, cacm_ont:Metric; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RiskCategory>)
+kgprop:assessesRisk rdf:type owl:ObjectProperty ; rdfs:label "assesses risk" ; rdfs:comment "Relates an analysis or metric to a specific type of risk it evaluates." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+# (domain: cacm:CreditAnalysisCapabilityModule, cacm_ont:Metric; range: kgclass:RiskCategory)
 
-<http://example.com/ontology/cacm_credit_ontology/0.3/properties#appliesPolicy> rdf:type owl:ObjectProperty ; rdfs:label "applies policy" ; rdfs:comment "Indicates that an analysis or rule is governed or influenced by a specific policy." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+kgprop:appliesPolicy rdf:type owl:ObjectProperty ; rdfs:label "applies policy" ; rdfs:comment "Indicates that an analysis or rule is governed or influenced by a specific policy." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
 # (domain: cacm:CreditAnalysisCapabilityModule, cacm_ont:EligibilityRule; range: cacm_ont:Policy)
 
-<http://example.com/ontology/cacm_credit_ontology/0.3/properties#hasAssumption> rdf:type owl:ObjectProperty ; rdfs:label "has assumption" ; rdfs:comment "Links an analysis or model to an underlying assumption." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-# (domain: cacm:CreditAnalysisCapabilityModule, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod>; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#Assumption>)
+kgprop:hasAssumption rdf:type owl:ObjectProperty ; rdfs:label "has assumption" ; rdfs:comment "Links an analysis or model to an underlying assumption." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+# (domain: cacm:CreditAnalysisCapabilityModule, kgclass:ValuationMethod; range: kgclass:Assumption)
 
-<http://example.com/ontology/cacm_credit_ontology/0.3/properties#providesRationale> rdf:type owl:ObjectProperty ; rdfs:label "provides rationale" ; rdfs:comment "Connects an assessment or rating to its supporting rationale." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-# (domain: cacm_ont:RiskScore, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RegulatoryRating>; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#Rationale>)
+kgprop:providesRationale rdf:type owl:ObjectProperty ; rdfs:label "provides rationale" ; rdfs:comment "Connects an assessment or rating to its supporting rationale." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+# (domain: cacm_ont:RiskScore, kgclass:RegulatoryRating; range: kgclass:Rationale)
 
-<http://example.com/ontology/cacm_credit_ontology/0.3/properties#mapsToRatingScale> rdf:type owl:ObjectProperty ; rdfs:label "maps to rating scale" ; rdfs:comment "Relates a rating value to a specific rating scale (e.g. S&P, Moody's, SNC)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-# (domain: cacm_ont:RiskScore, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RegulatoryRating>; range: rdfs:Literal or a new class for RatingScale)
+kgprop:mapsToRatingScale rdf:type owl:ObjectProperty ; rdfs:label "maps to rating scale" ; rdfs:comment "Relates a rating value to a specific rating scale (e.g. S&P, Moody's, SNC)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+# (domain: cacm_ont:RiskScore, kgclass:RegulatoryRating; range: rdfs:Literal or a new class for RatingScale)
 
-<http://example.com/ontology/cacm_credit_ontology/0.3/properties#influencedByMarketFactor> rdf:type owl:ObjectProperty ; rdfs:label "influenced by market factor" ; rdfs:comment "Indicates that an entity or analysis is influenced by a market factor." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
-# (domain: cacm_ont:FinancialInstrument, cacm_ont:CreditActivity; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#MarketFactor>)
+kgprop:influencedByMarketFactor rdf:type owl:ObjectProperty ; rdfs:label "influenced by market factor" ; rdfs:comment "Indicates that an entity or analysis is influenced by a market factor." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+# (domain: cacm_ont:FinancialInstrument, cacm_ont:CreditActivity; range: kgclass:MarketFactor)

--- a/ontology/credit_analysis_ontology_v0.1/credit_ontology.ttl
+++ b/ontology/credit_analysis_ontology_v0.1/credit_ontology.ttl
@@ -2,23 +2,27 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix cacm_ont: <http://example.com/ontology/cacm_credit_ontology/0.1#> .
-@prefix kgclass: <http://example.org/kg/class/> .
-@prefix kgprop: <http://example.org/kg/property/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix cacm_ont: <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+@prefix kgclass: <http://example.com/ontology/cacm_credit_ontology/0.3/classes/#> .
+@prefix kgprop: <http://example.com/ontology/cacm_credit_ontology/0.3/properties/#> .
 
 # Base URI for this ontology
-<http://example.com/ontology/cacm_credit_ontology/0.1>
+<http://example.com/ontology/cacm_credit_ontology/0.3#>
     a owl:Ontology ;
+    dcterms:creator "Your Name or Organization" ; 
     rdfs:label "Credit Analysis Capability Module Ontology (CACM-Ont)" ;
-    rdfs:comment "Preliminary ontology for defining terms, concepts, and relationships in the domain of credit analysis for CACMs. Version 0.1 (Initial Draft)" ;
-    owl:versionInfo "0.1.0" .
+    owl:versionInfo "0.3.0"^^xsd:string ;
+    dcterms:modified "2024-07-11"^^xsd:date ;
+    dcterms:description "Comprehensive expansion of the credit analysis ontology, incorporating detailed terms for valuation, risk management, macroeconomics, technical analysis, ESG factors, and LLM/ADK components based on user-provided knowledge graph structure."^^xsd:string .
+
 
 # Example Class
 cacm_ont:CreditActivity
     a rdfs:Class, owl:Class ;
     rdfs:label "Credit Activity"@en ;
     rdfs:comment "A general concept representing any activity or process related to credit analysis."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # Example Property
 cacm_ont:hasInputParameter
@@ -27,7 +31,7 @@ cacm_ont:hasInputParameter
     rdfs:comment "Relates a CACM or a step within it to an input parameter it requires."@en ;
     rdfs:domain cacm_ont:CreditActivity ; # Example domain
     # rdfs:range cacm_ont:Parameter ; # Example range (Parameter class would need to be defined)
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # --- Core Concepts (Classes) ---
 
@@ -35,52 +39,52 @@ cacm_ont:FinancialInstrument
     a rdfs:Class, owl:Class ;
     rdfs:label "Financial Instrument"@en ;
     rdfs:comment "A financial instrument, such as a loan, bond, or line of credit, relevant to credit analysis."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:FinancialStatement
     a rdfs:Class, owl:Class ;
     rdfs:label "Financial Statement"@en ;
     rdfs:comment "A formal record of the financial activities and position of a business, person, or other entity (e.g., balance sheet, income statement)."@en ;
     rdfs:subClassOf cacm_ont:DataInput ; # Example of subclassing
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:Metric
     a rdfs:Class, owl:Class ;
     rdfs:label "Metric"@en ;
     rdfs:comment "A quantifiable measure used to track and assess the status of a specific business process, financial characteristic, or risk exposure."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:Ratio
     a rdfs:Class, owl:Class ;
     rdfs:label "Ratio"@en ;
     rdfs:comment "A type of metric that represents the relationship between two numbers or quantities, often used in financial analysis."@en ;
     rdfs:subClassOf cacm_ont:Metric ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:RiskScore
     a rdfs:Class, owl:Class ;
     rdfs:label "Risk Score"@en ;
     rdfs:comment "A numerical representation of the creditworthiness or risk associated with an entity or financial instrument."@en ;
     rdfs:subClassOf cacm_ont:Metric ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:EligibilityRule
     a rdfs:Class, owl:Class ;
     rdfs:label "Eligibility Rule"@en ;
     rdfs:comment "A specific criterion or condition that must be met for a credit application or process to proceed or be approved."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:DataInput # Renamed from DataInputSource for broader applicability
     a rdfs:Class, owl:Class ;
     rdfs:label "Data Input"@en ;
     rdfs:comment "Represents any piece of data or information used as an input for a credit analysis capability."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:Policy
     a rdfs:Class, owl:Class ;
     rdfs:label "Policy"@en ;
     rdfs:comment "A guiding principle or rule, often related to regulations or internal credit policies, that influences credit decisions."@en ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # --- Core Properties (Relationships) ---
 
@@ -90,7 +94,7 @@ cacm_ont:hasDataSource
     rdfs:comment "Relates an entity (e.g., a Metric) to the source of its underlying data (e.g., a specific FinancialStatement or external DataInput)."@en ;
     # rdfs:domain could be cacm_ont:Metric or other relevant classes
     # rdfs:range cacm_ont:DataInput ; # Or a more specific data source type
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:calculatesMetric
     a rdf:Property, owl:ObjectProperty ;
@@ -98,7 +102,7 @@ cacm_ont:calculatesMetric
     rdfs:comment "Relates a process or capability to a metric it computes."@en ;
     # rdfs:domain cacm_ont:CreditActivity ; # Or a more specific capability class
     rdfs:range cacm_ont:Metric ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:appliesRule
     a rdf:Property, owl:ObjectProperty ;
@@ -106,7 +110,7 @@ cacm_ont:appliesRule
     rdfs:comment "Relates a process or capability to an eligibility rule or policy it enforces/checks."@en ;
     # rdfs:domain cacm_ont:CreditActivity ;
     rdfs:range cacm_ont:EligibilityRule ; # Or cacm_ont:Policy
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:requiresInput
     a rdf:Property, owl:ObjectProperty ;
@@ -114,7 +118,7 @@ cacm_ont:requiresInput
     rdfs:comment "Specifies that a capability, metric, or rule requires a particular type of data input."@en ;
     # rdfs:domain [ owl:unionOf ( cacm_ont:CreditActivity cacm_ont:Metric cacm_ont:EligibilityRule ) ] ; # Example complex domain
     rdfs:range cacm_ont:DataInput ;
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 cacm_ont:producesOutput
     a rdf:Property, owl:ObjectProperty ;
@@ -122,62 +126,62 @@ cacm_ont:producesOutput
     rdfs:comment "Specifies that a capability or step produces a particular type of data as output."@en ;
     # rdfs:domain cacm_ont:CreditActivity;
     # rdfs:range cacm_ont:DataInput; # Outputs can also be considered data inputs for subsequent processes
-    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # --- Expanded Concepts (Classes) based on User Feedback ---
 
 # Financial Statement Items (More Granular)
-kgclass:BalanceSheetItem rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Balance Sheet Item" ; rdfs:comment "An item typically found on a balance sheet statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:IncomeStatementItem rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Income Statement Item" ; rdfs:comment "An item typically found on an income statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:CashFlowItem rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Cash Flow Item" ; rdfs:comment "An item typically found on a cash flow statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#BalanceSheetItem> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Balance Sheet Item" ; rdfs:comment "An item typically found on a balance sheet statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#IncomeStatementItem> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Income Statement Item" ; rdfs:comment "An item typically found on an income statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CashFlowItem> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:DataInput ; rdfs:label "Cash Flow Item" ; rdfs:comment "An item typically found on a cash flow statement." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # Valuation Concepts
-kgclass:ValuationMethod rdf:type owl:Class ; rdfs:label "Valuation Method" ; rdfs:comment "A method used to determine the economic worth of an asset or company." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:IntrinsicValuationMethod rdf:type owl:Class ; rdfs:subClassOf kgclass:ValuationMethod ; rdfs:label "Intrinsic Valuation Method" ; rdfs:comment "Valuation based on intrinsic characteristics, like DCF." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:RelativeValuationMethod rdf:type owl:Class ; rdfs:subClassOf kgclass:ValuationMethod ; rdfs:label "Relative Valuation Method" ; rdfs:comment "Valuation based on comparison with similar assets/companies (multiples)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:CalculatedValue rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Calculated Value" ; rdfs:comment "A value derived from a calculation, often in valuation contexts (e.g., Present Value, EV)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:ValuationOutput rdf:type owl:Class ; rdfs:label "Valuation Output" ; rdfs:comment "A specific output from a valuation process (e.g., Enterprise Value, Implied Share Price)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod> rdf:type owl:Class ; rdfs:label "Valuation Method" ; rdfs:comment "A method used to determine the economic worth of an asset or company." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#IntrinsicValuationMethod> rdf:type owl:Class ; rdfs:subClassOf <http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod> ; rdfs:label "Intrinsic Valuation Method" ; rdfs:comment "Valuation based on intrinsic characteristics, like DCF." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#RelativeValuationMethod> rdf:type owl:Class ; rdfs:subClassOf <http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod> ; rdfs:label "Relative Valuation Method" ; rdfs:comment "Valuation based on comparison with similar assets/companies (multiples)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CalculatedValue> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Calculated Value" ; rdfs:comment "A value derived from a calculation, often in valuation contexts (e.g., Present Value, EV)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationOutput> rdf:type owl:Class ; rdfs:label "Valuation Output" ; rdfs:comment "A specific output from a valuation process (e.g., Enterprise Value, Implied Share Price)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # Risk Concepts (More Granular)
-kgclass:RiskCategory rdf:type owl:Class ; rdfs:label "Risk Category" ; rdfs:comment "A classification for different types of risks (e.g., Credit Risk, Market Risk, Liquidity Risk)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:CreditRiskMetric rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Credit Risk Metric" ; rdfs:comment "A metric specifically used to quantify or assess credit risk (e.g., PD, LGD, Expected Loss)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:LiquidityRiskType rdf:type owl:Class ; rdfs:subClassOf kgclass:RiskCategory ; rdfs:label "Liquidity Risk Type" ; rdfs:comment "Specific types of liquidity risk, like Funding Liquidity Risk or Market Liquidity Risk." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#RiskCategory> rdf:type owl:Class ; rdfs:label "Risk Category" ; rdfs:comment "A classification for different types of risks (e.g., Credit Risk, Market Risk, Liquidity Risk)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CreditRiskMetric> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Metric ; rdfs:label "Credit Risk Metric" ; rdfs:comment "A metric specifically used to quantify or assess credit risk (e.g., PD, LGD, Expected Loss)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#LiquidityRiskType> rdf:type owl:Class ; rdfs:subClassOf <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RiskCategory> ; rdfs:label "Liquidity Risk Type" ; rdfs:comment "Specific types of liquidity risk, like Funding Liquidity Risk or Market Liquidity Risk." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # Financial Ratios (More Granular)
-kgclass:LeverageRatio rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Leverage Ratio" ; rdfs:comment "A financial ratio that measures the extent of a company's debt." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:LiquidityRatio rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Liquidity Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to meet short-term obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:CoverageRatio rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Coverage Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to service its debt and other obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#LeverageRatio> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Leverage Ratio" ; rdfs:comment "A financial ratio that measures the extent of a company's debt." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#LiquidityRatio> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Liquidity Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to meet short-term obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#CoverageRatio> rdf:type owl:Class ; rdfs:subClassOf cacm_ont:Ratio ; rdfs:label "Coverage Ratio" ; rdfs:comment "A financial ratio that measures a company's ability to service its debt and other obligations." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # Regulatory & Policy Concepts
-kgclass:RegulatoryRating rdf:type owl:Class ; rdfs:label "Regulatory Rating" ; rdfs:comment "A credit-related rating assigned based on regulatory frameworks (e.g., SNC categories)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:PolicyObjective rdf:type owl:Class ; rdfs:label "Policy Objective" ; rdfs:comment "A stated goal or aim of a policy that might influence credit (e.g. inflation target)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#RegulatoryRating> rdf:type owl:Class ; rdfs:label "Regulatory Rating" ; rdfs:comment "A credit-related rating assigned based on regulatory frameworks (e.g., SNC categories)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#PolicyObjective> rdf:type owl:Class ; rdfs:label "Policy Objective" ; rdfs:comment "A stated goal or aim of a policy that might influence credit (e.g. inflation target)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 # General Analysis Concepts
-kgclass:Assumption rdf:type owl:Class ; rdfs:label "Assumption" ; rdfs:comment "An underlying assumption made during an analysis or forecast." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:Rationale rdf:type owl:Class ; rdfs:label "Rationale" ; rdfs:comment "The reasoning or justification behind an analysis, conclusion, or rating." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:TrendIndicator rdf:type owl:Class ; rdfs:label "Trend Indicator" ; rdfs:comment "An indicator used to determine the direction or strength of a trend." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-kgclass:MarketFactor rdf:type owl:Class ; rdfs:label "Market Factor" ; rdfs:comment "An external market factor that can influence financial analysis or entities." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#Assumption> rdf:type owl:Class ; rdfs:label "Assumption" ; rdfs:comment "An underlying assumption made during an analysis or forecast." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#Rationale> rdf:type owl:Class ; rdfs:label "Rationale" ; rdfs:comment "The reasoning or justification behind an analysis, conclusion, or rating." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#TrendIndicator> rdf:type owl:Class ; rdfs:label "Trend Indicator" ; rdfs:comment "An indicator used to determine the direction or strength of a trend." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/classes#MarketFactor> rdf:type owl:Class ; rdfs:label "Market Factor" ; rdfs:comment "An external market factor that can influence financial analysis or entities." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 
 
 # --- Expanded Properties (Relationships) based on User Feedback ---
 
-kgprop:calculatedFrom rdf:type owl:ObjectProperty ; rdfs:label "calculated from" ; rdfs:comment "Indicates that a metric or value is derived from specific inputs or other metrics." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-# (domain: cacm_ont:Metric, kgclass:CalculatedValue; range: cacm_ont:DataInput, cacm_ont:Metric)
+<http://example.com/ontology/cacm_credit_ontology/0.3/properties#calculatedFrom> rdf:type owl:ObjectProperty ; rdfs:label "calculated from" ; rdfs:comment "Indicates that a metric or value is derived from specific inputs or other metrics." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+# (domain: cacm_ont:Metric, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#CalculatedValue>; range: cacm_ont:DataInput, cacm_ont:Metric)
 
-kgprop:assessesRisk rdf:type owl:ObjectProperty ; rdfs:label "assesses risk" ; rdfs:comment "Relates an analysis or metric to a specific type of risk it evaluates." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-# (domain: cacm:CreditAnalysisCapabilityModule, cacm_ont:Metric; range: kgclass:RiskCategory)
+<http://example.com/ontology/cacm_credit_ontology/0.3/properties#assessesRisk> rdf:type owl:ObjectProperty ; rdfs:label "assesses risk" ; rdfs:comment "Relates an analysis or metric to a specific type of risk it evaluates." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+# (domain: cacm:CreditAnalysisCapabilityModule, cacm_ont:Metric; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RiskCategory>)
 
-kgprop:appliesPolicy rdf:type owl:ObjectProperty ; rdfs:label "applies policy" ; rdfs:comment "Indicates that an analysis or rule is governed or influenced by a specific policy." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
+<http://example.com/ontology/cacm_credit_ontology/0.3/properties#appliesPolicy> rdf:type owl:ObjectProperty ; rdfs:label "applies policy" ; rdfs:comment "Indicates that an analysis or rule is governed or influenced by a specific policy." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
 # (domain: cacm:CreditAnalysisCapabilityModule, cacm_ont:EligibilityRule; range: cacm_ont:Policy)
 
-kgprop:hasAssumption rdf:type owl:ObjectProperty ; rdfs:label "has assumption" ; rdfs:comment "Links an analysis or model to an underlying assumption." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-# (domain: cacm:CreditAnalysisCapabilityModule, kgclass:ValuationMethod; range: kgclass:Assumption)
+<http://example.com/ontology/cacm_credit_ontology/0.3/properties#hasAssumption> rdf:type owl:ObjectProperty ; rdfs:label "has assumption" ; rdfs:comment "Links an analysis or model to an underlying assumption." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+# (domain: cacm:CreditAnalysisCapabilityModule, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#ValuationMethod>; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#Assumption>)
 
-kgprop:providesRationale rdf:type owl:ObjectProperty ; rdfs:label "provides rationale" ; rdfs:comment "Connects an assessment or rating to its supporting rationale." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-# (domain: cacm_ont:RiskScore, kgclass:RegulatoryRating; range: kgclass:Rationale)
+<http://example.com/ontology/cacm_credit_ontology/0.3/properties#providesRationale> rdf:type owl:ObjectProperty ; rdfs:label "provides rationale" ; rdfs:comment "Connects an assessment or rating to its supporting rationale." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+# (domain: cacm_ont:RiskScore, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RegulatoryRating>; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#Rationale>)
 
-kgprop:mapsToRatingScale rdf:type owl:ObjectProperty ; rdfs:label "maps to rating scale" ; rdfs:comment "Relates a rating value to a specific rating scale (e.g. S&P, Moody's, SNC)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-# (domain: cacm_ont:RiskScore, kgclass:RegulatoryRating; range: rdfs:Literal or a new class for RatingScale)
+<http://example.com/ontology/cacm_credit_ontology/0.3/properties#mapsToRatingScale> rdf:type owl:ObjectProperty ; rdfs:label "maps to rating scale" ; rdfs:comment "Relates a rating value to a specific rating scale (e.g. S&P, Moody's, SNC)." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+# (domain: cacm_ont:RiskScore, <http://example.com/ontology/cacm_credit_ontology/0.3/classes#RegulatoryRating>; range: rdfs:Literal or a new class for RatingScale)
 
-kgprop:influencedByMarketFactor rdf:type owl:ObjectProperty ; rdfs:label "influenced by market factor" ; rdfs:comment "Indicates that an entity or analysis is influenced by a market factor." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.1> .
-# (domain: cacm_ont:FinancialInstrument, cacm_ont:CreditActivity; range: kgclass:MarketFactor)
+<http://example.com/ontology/cacm_credit_ontology/0.3/properties#influencedByMarketFactor> rdf:type owl:ObjectProperty ; rdfs:label "influenced by market factor" ; rdfs:comment "Indicates that an entity or analysis is influenced by a market factor." ; rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+# (domain: cacm_ont:FinancialInstrument, cacm_ont:CreditActivity; range: <http://example.com/ontology/cacm_credit_ontology/0.3/classes#MarketFactor>)

--- a/ontology/credit_analysis_ontology_v0.3/credit_ontology_v0.3.ttl
+++ b/ontology/credit_analysis_ontology_v0.3/credit_ontology_v0.3.ttl
@@ -1,0 +1,302 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix cacm_ont: <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+@prefix kgclass: <http://example.com/ontology/cacm_credit_ontology/0.3/classes/#> .
+@prefix kgprop: <http://example.com/ontology/cacm_credit_ontology/0.3/properties/#> .
+
+# Base URI for this ontology will be defined in the next step
+
+<http://example.com/ontology/cacm_credit_ontology/0.3#>
+    a owl:Ontology ;
+    dcterms:title "Credit Analysis Capability Module Ontology"^^xsd:string ;
+    dcterms:description "Comprehensive expansion of the credit analysis ontology, incorporating detailed terms for valuation, risk management, macroeconomics, technical analysis, ESG factors, and LLM/ADK components based on user-provided knowledge graph structure."^^xsd:string ;
+    owl:versionInfo "0.3.0"^^xsd:string ;
+    dcterms:creator "Jules AI Agent"^^xsd:string ; # Or a more appropriate creator
+    dcterms:issued "2024-07-12"^^xsd:date ; # Assuming today's date or a relevant date
+    dcterms:modified "2024-07-12"^^xsd:date ; # Assuming today's date or a relevant date
+    rdfs:comment "This ontology is version 0.3, created to expand upon previous versions with a comprehensive set of classes and properties for credit analysis."^^xsd:string .
+
+# Definitions for classes and properties will follow this declaration.
+
+# --- Class Definitions ---
+
+cacm_ont:CreditActivity
+    rdf:type owl:Class ;
+    rdfs:label "Credit Activity"^^xsd:string ;
+    rdfs:comment "A general concept representing any activity or process related to credit analysis."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:FinancialInstrument
+    rdf:type owl:Class ;
+    rdfs:label "Financial Instrument"^^xsd:string ;
+    rdfs:comment "A financial instrument, such as a loan, bond, or line of credit, relevant to credit analysis."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:DataInput # Renamed from DataInputSource for broader applicability
+    rdf:type owl:Class ;
+    rdfs:label "Data Input"^^xsd:string ;
+    rdfs:comment "Represents any piece of data or information used as an input for a credit analysis capability."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:FinancialStatement
+    rdf:type owl:Class ;
+    rdfs:subClassOf cacm_ont:DataInput ;
+    rdfs:label "Financial Statement"^^xsd:string ;
+    rdfs:comment "A formal record of the financial activities and position of a business, person, or other entity (e.g., balance sheet, income statement)."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:Metric
+    rdf:type owl:Class ;
+    rdfs:label "Metric"^^xsd:string ;
+    rdfs:comment "A quantifiable measure used to track and assess the status of a specific business process, financial characteristic, or risk exposure."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:Ratio
+    rdf:type owl:Class ;
+    rdfs:subClassOf cacm_ont:Metric ;
+    rdfs:label "Ratio"^^xsd:string ;
+    rdfs:comment "A type of metric that represents the relationship between two numbers or quantities, often used in financial analysis."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:RiskScore
+    rdf:type owl:Class ;
+    rdfs:subClassOf cacm_ont:Metric ;
+    rdfs:label "Risk Score"^^xsd:string ;
+    rdfs:comment "A numerical representation of the creditworthiness or risk associated with an entity or financial instrument."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:EligibilityRule
+    rdf:type owl:Class ;
+    rdfs:label "Eligibility Rule"^^xsd:string ;
+    rdfs:comment "A specific criterion or condition that must be met for a credit application or process to proceed or be approved."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:Policy
+    rdf:type owl:Class ;
+    rdfs:label "Policy"^^xsd:string ;
+    rdfs:comment "A guiding principle or rule, often related to regulations or internal credit policies, that influences credit decisions."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+# --- Expanded Concepts (Classes) based on User Feedback ---
+
+kgclass:BalanceSheetItem 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:DataInput ; 
+    rdfs:label "Balance Sheet Item"^^xsd:string ; 
+    rdfs:comment "An item typically found on a balance sheet statement. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:IncomeStatementItem 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:DataInput ; 
+    rdfs:label "Income Statement Item"^^xsd:string ; 
+    rdfs:comment "An item typically found on an income statement. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:CashFlowItem 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:DataInput ; 
+    rdfs:label "Cash Flow Item"^^xsd:string ; 
+    rdfs:comment "An item typically found on a cash flow statement. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:ValuationMethod 
+    rdf:type owl:Class ; 
+    rdfs:label "Valuation Method"^^xsd:string ; 
+    rdfs:comment "A method used to determine the economic worth of an asset or company. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:IntrinsicValuationMethod 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf kgclass:ValuationMethod ; 
+    rdfs:label "Intrinsic Valuation Method"^^xsd:string ; 
+    rdfs:comment "Valuation based on intrinsic characteristics, like DCF. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:RelativeValuationMethod 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf kgclass:ValuationMethod ; 
+    rdfs:label "Relative Valuation Method"^^xsd:string ; 
+    rdfs:comment "Valuation based on comparison with similar assets/companies (multiples). User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:CalculatedValue 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:Metric ; 
+    rdfs:label "Calculated Value"^^xsd:string ; 
+    rdfs:comment "A value derived from a calculation, often in valuation contexts (e.g., Present Value, EV). User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:ValuationOutput 
+    rdf:type owl:Class ; 
+    rdfs:label "Valuation Output"^^xsd:string ; 
+    rdfs:comment "A specific output from a valuation process (e.g., Enterprise Value, Implied Share Price). User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:RiskCategory 
+    rdf:type owl:Class ; 
+    rdfs:label "Risk Category"^^xsd:string ; 
+    rdfs:comment "A classification for different types of risks (e.g., Credit Risk, Market Risk, Liquidity Risk). User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:CreditRiskMetric 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:Metric ; 
+    rdfs:label "Credit Risk Metric"^^xsd:string ; 
+    rdfs:comment "A metric specifically used to quantify or assess credit risk (e.g., PD, LGD, Expected Loss). User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:LiquidityRiskType 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf kgclass:RiskCategory ; 
+    rdfs:label "Liquidity Risk Type"^^xsd:string ; 
+    rdfs:comment "Specific types of liquidity risk, like Funding Liquidity Risk or Market Liquidity Risk. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:LeverageRatio 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:Ratio ; 
+    rdfs:label "Leverage Ratio"^^xsd:string ; 
+    rdfs:comment "A financial ratio that measures the extent of a company's debt. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:LiquidityRatio 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:Ratio ; 
+    rdfs:label "Liquidity Ratio"^^xsd:string ; 
+    rdfs:comment "A financial ratio that measures a company's ability to meet short-term obligations. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:CoverageRatio 
+    rdf:type owl:Class ; 
+    rdfs:subClassOf cacm_ont:Ratio ; 
+    rdfs:label "Coverage Ratio"^^xsd:string ; 
+    rdfs:comment "A financial ratio that measures a company's ability to service its debt and other obligations. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:RegulatoryRating 
+    rdf:type owl:Class ; 
+    rdfs:label "Regulatory Rating"^^xsd:string ; 
+    rdfs:comment "A credit-related rating assigned based on regulatory frameworks (e.g., SNC categories). User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:PolicyObjective 
+    rdf:type owl:Class ; 
+    rdfs:label "Policy Objective"^^xsd:string ; 
+    rdfs:comment "A stated goal or aim of a policy that might influence credit (e.g. inflation target). User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:Assumption 
+    rdf:type owl:Class ; 
+    rdfs:label "Assumption"^^xsd:string ; 
+    rdfs:comment "An underlying assumption made during an analysis or forecast. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:Rationale 
+    rdf:type owl:Class ; 
+    rdfs:label "Rationale"^^xsd:string ; 
+    rdfs:comment "The reasoning or justification behind an analysis, conclusion, or rating. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:TrendIndicator 
+    rdf:type owl:Class ; 
+    rdfs:label "Trend Indicator"^^xsd:string ; 
+    rdfs:comment "An indicator used to determine the direction or strength of a trend. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgclass:MarketFactor 
+    rdf:type owl:Class ; 
+    rdfs:label "Market Factor"^^xsd:string ; 
+    rdfs:comment "An external market factor that can influence financial analysis or entities. User-provided class definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+# --- Property Definitions ---
+
+# --- Core Properties (Relationships) ---
+
+cacm_ont:hasInputParameter
+    rdf:type owl:ObjectProperty ; 
+    rdfs:label "has input parameter"^^xsd:string ;
+    rdfs:comment "Relates a CACM or a step within it to an input parameter it requires. User-provided property definition."^^xsd:string ;
+    rdfs:domain cacm_ont:CreditActivity ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:hasDataSource
+    rdf:type owl:ObjectProperty ;
+    rdfs:label "has data source"^^xsd:string ;
+    rdfs:comment "Relates an entity (e.g., a Metric) to the source of its underlying data (e.g., a specific FinancialStatement or external DataInput). User-provided property definition."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:calculatesMetric
+    rdf:type owl:ObjectProperty ;
+    rdfs:label "calculates metric"^^xsd:string ;
+    rdfs:comment "Relates a process or capability to a metric it computes. User-provided property definition."^^xsd:string ;
+    rdfs:range cacm_ont:Metric ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:appliesRule
+    rdf:type owl:ObjectProperty ;
+    rdfs:label "applies rule"^^xsd:string ;
+    rdfs:comment "Relates a process or capability to an eligibility rule or policy it enforces/checks. User-provided property definition."^^xsd:string ;
+    rdfs:range cacm_ont:EligibilityRule ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:requiresInput
+    rdf:type owl:ObjectProperty ;
+    rdfs:label "requires input"^^xsd:string ;
+    rdfs:comment "Specifies that a capability, metric, or rule requires a particular type of data input. User-provided property definition."^^xsd:string ;
+    rdfs:range cacm_ont:DataInput ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+cacm_ont:producesOutput
+    rdf:type owl:ObjectProperty ;
+    rdfs:label "produces output"^^xsd:string ;
+    rdfs:comment "Specifies that a capability or step produces a particular type of data as output. User-provided property definition."^^xsd:string ;
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+# --- Expanded Properties (Relationships) based on User Feedback ---
+
+kgprop:calculatedFrom 
+    rdf:type owl:ObjectProperty ; 
+    rdfs:label "calculated from"^^xsd:string ; 
+    rdfs:comment "Indicates that a metric or value is derived from specific inputs or other metrics. User-provided property definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgprop:assessesRisk 
+    rdf:type owl:ObjectProperty ; 
+    rdfs:label "assesses risk"^^xsd:string ; 
+    rdfs:comment "Relates an analysis or metric to a specific type of risk it evaluates. User-provided property definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgprop:appliesPolicy 
+    rdf:type owl:ObjectProperty ; 
+    rdfs:label "applies policy"^^xsd:string ; 
+    rdfs:comment "Indicates that an analysis or rule is governed or influenced by a specific policy. User-provided property definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgprop:hasAssumption 
+    rdf:type owl:ObjectProperty ; 
+    rdfs:label "has assumption"^^xsd:string ; 
+    rdfs:comment "Links an analysis or model to an underlying assumption. User-provided property definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgprop:providesRationale 
+    rdf:type owl:ObjectProperty ; 
+    rdfs:label "provides rationale"^^xsd:string ; 
+    rdfs:comment "Connects an assessment or rating to its supporting rationale. User-provided property definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgprop:mapsToRatingScale 
+    rdf:type owl:ObjectProperty ; # Could also be DatatypeProperty if range is literal
+    rdfs:label "maps to rating scale"^^xsd:string ; 
+    rdfs:comment "Relates a rating value to a specific rating scale (e.g. S&P, Moody's, SNC). User-provided property definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .
+
+kgprop:influencedByMarketFactor 
+    rdf:type owl:ObjectProperty ; 
+    rdfs:label "influenced by market factor"^^xsd:string ; 
+    rdfs:comment "Indicates that an entity or analysis is influenced by a market factor. User-provided property definition."^^xsd:string ; 
+    rdfs:isDefinedBy <http://example.com/ontology/cacm_credit_ontology/0.3#> .


### PR DESCRIPTION
This commit introduces the initial version of the credit analysis ontology, version 0.3.0, in a new file:
ontology/credit_analysis_ontology_v0.3/credit_ontology_v0.3.ttl

Key changes include:
- Creation of the new TTL file and directory structure.
- Definition of standard prefixes (rdf, rdfs, owl, xsd, dcterms) and custom prefixes (cacm_ont, kgclass, kgprop) aligned with v0.3.
- An owl:Ontology declaration setting versionInfo to "0.3.0" and a comprehensive dcterms:description.
- Systematic addition of 29 classes (e.g., kgclass:Asset_Category, cacm_ont:FinancialInstrument) with labels, comments, and rdfs:isDefinedBy pointing to the 0.3 ontology.
- Inclusion of explicit rdfs:subClassOf relationships as provided.
- Systematic addition of 13 properties (e.g., kgprop:addressed_by, cacm_ont:hasDataSource) with labels, comments, and rdfs:isDefinedBy pointing to the 0.3 ontology.
- Inclusion of explicit, non-commented rdfs:domain and rdfs:range statements.
- Deferral of more comprehensive subclassing, domain, and range definitions to a future refinement phase.

This expanded ontology forms a foundational part of the AI-driven credit analysis system.