### PR TITLE
feat: Create basic HTML LLM prompt interface

### DIFF
--- a/llm_prompt_ui/.gitkeep
+++ b/llm_prompt_ui/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure that Git tracks this directory.

--- a/llm_prompt_ui/__init__.py
+++ b/llm_prompt_ui/__init__.py
@@ -1,0 +1,1 @@
+# This file intentionally left blank to mark the directory as a Python package.

--- a/llm_prompt_ui/app.py
+++ b/llm_prompt_ui/app.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return "Hello, World!"
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/llm_prompt_ui/config.py
+++ b/llm_prompt_ui/config.py
@@ -1,0 +1,4 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY') or 'you-will-never-guess'

--- a/llm_prompt_ui/static/.gitkeep
+++ b/llm_prompt_ui/static/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure that Git tracks this directory.

--- a/llm_prompt_ui/static/script.js
+++ b/llm_prompt_ui/static/script.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const promptButtons = document.querySelectorAll('.prompt-button');
+    const llmResponseElement = document.getElementById('llm-response');
+
+    if (!llmResponseElement) {
+        console.error('Error: Element with ID "llm-response" not found.');
+        return;
+    }
+
+    promptButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const promptText = button.dataset.prompt;
+            if (promptText) {
+                // Simulate LLM interaction by displaying the prompt text.
+                // In a real application, you would send this promptText to an LLM API
+                // and display the actual response.
+                llmResponseElement.textContent = promptText;
+                console.log('Prompt selected:', promptText);
+            } else {
+                llmResponseElement.textContent = 'Error: No prompt associated with this button.';
+                console.error('Error: Button does not have a data-prompt attribute or it is empty.');
+            }
+        });
+    });
+
+    // Initial message
+    if (promptButtons.length > 0) {
+        llmResponseElement.textContent = 'Click one of the buttons above to see its prompt here.';
+    } else {
+        llmResponseElement.textContent = 'No prompt buttons found on the page.';
+        console.warn('No elements with class "prompt-button" found.');
+    }
+});

--- a/llm_prompt_ui/static/style.css
+++ b/llm_prompt_ui/static/style.css
@@ -1,0 +1,59 @@
+body {
+    font-family: sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+    line-height: 1.6;
+}
+
+h1 {
+    color: #333;
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+#prompt-buttons {
+    display: flex;
+    flex-wrap: wrap; /* Allow buttons to wrap to the next line on smaller screens */
+    justify-content: center;
+    gap: 15px; /* Spacing between buttons */
+    margin-bottom: 30px;
+}
+
+.prompt-button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 12px 25px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.prompt-button:hover {
+    background-color: #0056b3;
+}
+
+#response-area {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin-top: 20px;
+}
+
+#response-area h2 {
+    margin-top: 0;
+    color: #555;
+}
+
+#llm-response {
+    font-size: 1.1em;
+    color: #444;
+    min-height: 50px; /* Ensure it has some height even when empty */
+    white-space: pre-wrap; /* Preserve whitespace and newlines in the response */
+}

--- a/llm_prompt_ui/templates/.gitkeep
+++ b/llm_prompt_ui/templates/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure that Git tracks this directory.

--- a/llm_prompt_ui/templates/index.html
+++ b/llm_prompt_ui/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LLM Prompt Interface</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>LLM Prompt Interface</h1>
+
+    <div id="prompt-buttons">
+        <button class="prompt-button" data-prompt="Explain quantum computing in simple terms.">Explain Quantum Computing</button>
+        <button class="prompt-button" data-prompt="What are the latest advancements in AI?">Latest AI Advancements</button>
+        <button class="prompt-button" data-prompt="Write a short story about a friendly robot.">Story about a Robot</button>
+        <button class="prompt-button" data-prompt="Suggest three fun activities for a rainy day.">Rainy Day Activities</button>
+    </div>
+
+    <div id="response-area">
+        <h2>Response:</h2>
+        <p id="llm-response">Click a button to see a prompt here.</p>
+    </div>
+
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>

--- a/llm_prompt_ui/utils.py
+++ b/llm_prompt_ui/utils.py
@@ -1,0 +1,1 @@
+# Utility functions will be added here.


### PR DESCRIPTION
This commit introduces a simple web interface that allows you to click buttons to send predefined prompts.

The interface consists of:
- An `index.html` file with the page structure, including buttons and a response display area.
- A `script.js` file to handle button clicks and display the selected prompt in the response area. This simulates the LLM interaction for now.
- A `style.css` file to provide basic styling for the page elements, making it more user-friendly.

The files are organized within a new `llm_prompt_ui` directory, which also includes a basic Flask app structure (though it's not actively used by this static interface yet).