### PR TITLE
feat: Create initial data mesh ontology framework

### DIFF
--- a/ontology/data_mesh_ontology/README.md
+++ b/ontology/data_mesh_ontology/README.md
@@ -1,0 +1,24 @@
+# Data Mesh Ontology
+
+This ontology defines the concepts and relationships for a data mesh architecture.
+
+## Core Concepts
+
+* **Data Product:** A data product is a self-contained unit of data that is owned and managed by a specific domain.
+* **Domain:** A domain is a specific area of business expertise.
+* **Data Contract:** A data contract defines the terms of use for a data product.
+* **Infrastructure Platform:** The infrastructure platform provides the underlying technology for the data mesh.
+
+## Relationships
+
+* A data product is owned by a domain.
+* A data product is governed by a data contract.
+* A data product is hosted on the infrastructure platform.
+
+## Usage
+
+This ontology can be used to:
+
+* Design and implement a data mesh architecture.
+* Understand the relationships between different data mesh components.
+* Communicate about data mesh concepts in a consistent way.

--- a/ontology/data_mesh_ontology/framework.py
+++ b/ontology/data_mesh_ontology/framework.py
@@ -1,0 +1,639 @@
+# This file will contain the Python code for the data mesh ontology framework.
+
+import uuid
+from datetime import datetime
+
+# --- Existing Classes (to be integrated or refined) ---
+# These classes represent the core components of a data mesh.
+# They will likely inherit from OntologyElement or be managed by the KnowledgeStore.
+
+class DataProduct:
+    """
+    Represents a self-contained unit of data, owned and managed by a specific domain.
+    It is a key concept in the data mesh paradigm.
+    """
+    def __init__(self, name, domain, description):
+        self.id = str(uuid.uuid4()) # Ensure DataProducts also have unique IDs
+        self.name = name
+        self.domain = domain # This could be a string or a Domain object
+        self.description = description
+        self.data_contract = None # This could be a DataContract object
+        self.version = "1.0.0" # Initial version
+        self.created_at = datetime.utcnow()
+        self.updated_at = datetime.utcnow()
+        # Further attributes: data sources, schema, quality metrics, etc.
+
+    def set_data_contract(self, data_contract):
+        self.data_contract = data_contract
+        self.updated_at = datetime.utcnow()
+
+class Domain:
+    """
+    Represents a specific area of business expertise or a logical grouping of data products.
+    Domains are responsible for owning and managing their data products.
+    """
+    def __init__(self, name, description):
+        self.id = str(uuid.uuid4())
+        self.name = name
+        self.description = description
+        self.data_products = [] # List of DataProduct objects or their IDs
+        self.created_at = datetime.utcnow()
+        self.updated_at = datetime.utcnow()
+        # Further attributes: domain owner, stakeholders, related business capabilities
+
+    def add_data_product(self, data_product):
+        if data_product not in self.data_products:
+            self.data_products.append(data_product)
+            self.updated_at = datetime.utcnow()
+
+class DataContract:
+    """
+    Defines the terms of use, schema, quality standards, and access policies for a data product.
+    It acts as an interface between data producers and consumers.
+    """
+    def __init__(self, version, terms_of_use, data_product_id):
+        self.id = str(uuid.uuid4())
+        self.version = version
+        self.terms_of_use = terms_of_use
+        self.data_product_id = data_product_id # Link to the specific DataProduct
+        self.schema_definition = {} # e.g., JSON Schema, Avro schema
+        self.quality_rules = [] # List of rules or metrics
+        self.access_policies = [] # Who can access and how
+        self.created_at = datetime.utcnow()
+        self.updated_at = datetime.utcnow()
+
+class InfrastructurePlatform:
+    """
+    Represents the underlying technology and services that support the data mesh.
+    This includes data storage, processing, governance tools, and CI/CD pipelines.
+    """
+    def __init__(self, name, technology_stack):
+        self.id = str(uuid.uuid4())
+        self.name = name
+        self.technology_stack = technology_stack # e.g., cloud provider, specific services
+        self.hosted_data_products = [] # List of DataProduct objects or IDs it supports
+        self.created_at = datetime.utcnow()
+        self.updated_at = datetime.utcnow()
+
+    def host_data_product(self, data_product):
+        # In a real implementation, this would involve deploying the data product to the platform.
+        print(f"Hosting data product {data_product.name} on {self.name}")
+        if data_product not in self.hosted_data_products:
+            self.hosted_data_products.append(data_product)
+            self.updated_at = datetime.utcnow()
+
+# --- Core Ontology Framework Classes ---
+
+class OntologyElement:
+    """
+    Base class for all elements within the ontology (e.g., concepts, relationships).
+    Provides common attributes like ID, name, description, and version.
+    """
+    def __init__(self, name, description, version="1.0.0"):
+        self.id = str(uuid.uuid4())  # Unique identifier for the ontology element
+        self.name = name  # Human-readable name of the element
+        self.description = description  # Detailed explanation of the element
+        self.version = version  # Version of the element definition
+        self.created_at = datetime.utcnow()
+        self.updated_at = datetime.utcnow()
+
+    def update_description(self, new_description):
+        self.description = new_description
+        self.updated_at = datetime.utcnow()
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}(id='{self.id}', name='{self.name}', version='{self.version}')>"
+
+class Concept(OntologyElement):
+    """
+    Represents a concept or class in the ontology (e.g., "Customer", "Product").
+    Concepts can have parent-child relationships (subclass/superclass) and be linked by relationships.
+    """
+    def __init__(self, name, description, version="1.0.0", parent_concepts=None, child_concepts=None):
+        super().__init__(name, description, version)
+        # List of Concept objects or their IDs
+        self.parent_concepts = parent_concepts if parent_concepts else []
+        # List of Concept objects or their IDs
+        self.child_concepts = child_concepts if child_concepts else []
+        # List of Relationship objects or their IDs where this concept is involved
+        self.related_relationships = []
+
+    def add_parent_concept(self, parent_concept):
+        if parent_concept not in self.parent_concepts:
+            self.parent_concepts.append(parent_concept)
+            self.updated_at = datetime.utcnow()
+
+    def add_child_concept(self, child_concept):
+        if child_concept not in self.child_concepts:
+            self.child_concepts.append(child_concept)
+            # Optionally, set this concept as a parent for the child
+            if self not in child_concept.parent_concepts:
+                child_concept.add_parent_concept(self)
+            self.updated_at = datetime.utcnow()
+
+    def add_relationship(self, relationship):
+        if relationship not in self.related_relationships:
+            self.related_relationships.append(relationship)
+            self.updated_at = datetime.utcnow()
+
+class Relationship(OntologyElement):
+    """
+    Represents a property or link between concepts in the ontology (e.g., "hasAddress", "worksFor").
+    Relationships have a domain (source concept) and a range (target concept or literal value).
+    They can also have characteristics like transitivity or symmetry.
+    """
+    def __init__(self, name, description, domain_concept, range_concept_or_literal, version="1.0.0",
+                 is_transitive=False, is_symmetric=False, is_functional=False):
+        super().__init__(name, description, version)
+        self.domain_concept = domain_concept  # The Concept from which the relationship originates
+        self.range_concept_or_literal = range_concept_or_literal  # The Concept or literal value to which it points
+        self.is_transitive = is_transitive  # e.g., if A related_to B and B related_to C, then A related_to C
+        self.is_symmetric = is_symmetric    # e.g., if A related_to B, then B related_to A
+        self.is_functional = is_functional    # e.g., for a given domain instance, there's at most one range instance
+
+    def update_characteristics(self, is_transitive=None, is_symmetric=None, is_functional=None):
+        if is_transitive is not None:
+            self.is_transitive = is_transitive
+        if is_symmetric is not None:
+            self.is_symmetric = is_symmetric
+        if is_functional is not None:
+            self.is_functional = is_functional
+        self.updated_at = datetime.utcnow()
+
+# --- Supporting Framework Classes ---
+
+class VersionControl:
+    """
+    Manages versions of ontology elements or the entire ontology.
+    This is a placeholder; a real implementation would integrate with systems like Git
+    or use a database with versioning capabilities.
+    """
+    def __init__(self):
+        self.history = {}  # Stores snapshots or changes; e.g., {element_id: [versions]}
+
+    def commit_changes(self, element, change_description="No description"):
+        """
+        Placeholder for committing changes to an ontology element.
+        In a real system, this would save the current state and metadata.
+        """
+        print(f"Committing changes for element {element.id} ({element.name}): {change_description}")
+        if element.id not in self.history:
+            self.history[element.id] = []
+        # Store a copy or a diff of the element
+        self.history[element.id].append({
+            "version": element.version,
+            "timestamp": datetime.utcnow(),
+            "description": change_description,
+            "snapshot": repr(element) # Simplified snapshot
+        })
+
+    def revert_to_version(self, element_id, target_version):
+        """
+        Placeholder for reverting an element to a previous version.
+        """
+        print(f"Reverting element {element_id} to version {target_version}")
+        # Logic to find and restore the element's state from history would go here.
+        pass
+
+    def get_history(self, element_id):
+        """
+        Placeholder for retrieving the version history of an element.
+        """
+        print(f"Retrieving history for element {element_id}")
+        return self.history.get(element_id, [])
+
+class Logger:
+    """
+    Provides logging capabilities for events within the ontology framework.
+    Useful for auditing, debugging, and tracking changes or system behavior.
+    """
+    def __init__(self, log_file="ontology_log.txt"):
+        self.log_file = log_file
+        self.logs = []
+
+    def log_event(self, event_type, message, severity="INFO", metadata=None):
+        """
+        Logs an event with a timestamp, type, message, severity, and optional metadata.
+        """
+        log_entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "event_type": event_type,
+            "message": message,
+            "severity": severity,
+            "metadata": metadata if metadata else {}
+        }
+        self.logs.append(log_entry)
+        # In a real system, this might write to a file, database, or logging service.
+        print(f"[{log_entry['timestamp']}] [{log_entry['severity']}] {log_entry['event_type']}: {log_entry['message']}")
+        with open(self.log_file, "a") as f:
+            f.write(f"{log_entry}\n")
+
+
+    def get_logs(self, event_type_filter=None, severity_filter=None):
+        """
+        Retrieves logs, optionally filtered by event type or severity.
+        """
+        filtered_logs = self.logs
+        if event_type_filter:
+            filtered_logs = [log for log in filtered_logs if log["event_type"] == event_type_filter]
+        if severity_filter:
+            filtered_logs = [log for log in filtered_logs if log["severity"] == severity_filter]
+        return filtered_logs
+
+class KnowledgeStore:
+    """
+    Manages the storage and retrieval of ontology elements and their instances.
+    This class can be a base or a manager for different types of data sources,
+    allowing the ontology to connect with various backend systems where data resides.
+    """
+    def __init__(self):
+        self.elements = {}  # In-memory store for ontology elements (concepts, relationships)
+        self.data_connectors = [] # List of connectors to actual data sources
+        # Example: self.database_connector = DatabaseConnector(...)
+        # Example: self.datalake_connector = DataLakeConnector(...)
+        # Example: self.api_connector = ApiConnector(...)
+
+    def add_element(self, element: OntologyElement):
+        """Adds an ontology element (Concept, Relationship) to the store."""
+        if element.id not in self.elements:
+            self.elements[element.id] = element
+            print(f"Element {element.name} (ID: {element.id}) added to KnowledgeStore.")
+        else:
+            print(f"Element {element.name} (ID: {element.id}) already exists. Updating.")
+            self.elements[element.id] = element # Or handle update logic
+
+    def get_element(self, element_id):
+        """Retrieves an ontology element by its ID."""
+        return self.elements.get(element_id)
+
+    def register_connector(self, connector):
+        """Registers a data connector (e.g., for a database, data lake)."""
+        self.data_connectors.append(connector)
+        print(f"Connector {connector.name} registered with KnowledgeStore.")
+
+    # Comments on handling different data types:
+    # For structured data (e.g., SQL databases):
+    #   - Connectors would use ODBC/JDBC or database-specific Python libraries.
+    #   - Mappings would be defined between ontology concepts/relationships and database tables/columns/relations.
+    #   - Queries could be translated from an ontology query language (e.g., SPARQL) to SQL.
+    # For unstructured data (e.g., text documents, images in a data lake):
+    #   - Connectors would interact with data lake APIs (e.g., S3, HDFS).
+    #   - Metadata tagging and semantic search (see SemanticSearch class) become crucial.
+    #   - NLP and computer vision techniques might be used to extract meaning and link to ontology concepts.
+
+class DatabaseConnector:
+    """Placeholder for connecting to structured databases (e.g., SQL, NoSQL graph DBs)."""
+    def __init__(self, name, connection_string, db_type="SQL"):
+        self.name = name
+        self.connection_string = connection_string
+        self.db_type = db_type
+        # Connection object would be managed here
+        print(f"DatabaseConnector '{name}' initialized for {db_type} at {connection_string}")
+
+    def query(self, query_string):
+        # Placeholder for executing a query
+        print(f"Executing query on {self.name}: {query_string}")
+        return [] # Return query results
+
+class DataLakeConnector:
+    """Placeholder for connecting to data lakes (e.g., S3, Azure Data Lake Storage)."""
+    def __init__(self, name, endpoint_url, access_credentials):
+        self.name = name
+        self.endpoint_url = endpoint_url
+        self.access_credentials = access_credentials # Securely manage this
+        print(f"DataLakeConnector '{name}' initialized for endpoint {endpoint_url}")
+
+    def retrieve_object(self, object_key):
+        # Placeholder for retrieving an object (file, document)
+        print(f"Retrieving object '{object_key}' from data lake {self.name}")
+        return None
+
+class ApiConnector:
+    """Placeholder for connecting to external or internal APIs."""
+    def __init__(self, name, base_url, auth_details=None):
+        self.name = name
+        self.base_url = base_url
+        self.auth_details = auth_details
+        print(f"ApiConnector '{name}' initialized for base URL {base_url}")
+
+    def get_data(self, endpoint, params=None):
+        # Placeholder for making a GET request
+        print(f"Fetching data from API {self.name}, endpoint {endpoint} with params {params}")
+        return {}
+
+
+class ContextManager:
+    """
+    Manages the current operational context for ontology-related tasks.
+    This could include user identity, active domain, specific data product focus,
+    or environmental settings (e.g., dev, test, prod).
+    """
+    def __init__(self):
+        self.current_context = {}
+
+    def set_context(self, key, value):
+        """Sets a specific piece of information in the current context."""
+        print(f"Setting context: {key} = {value}")
+        self.current_context[key] = value
+
+    def get_context(self, key):
+        """Retrieves a piece of information from the current context."""
+        return self.current_context.get(key)
+
+    def clear_context(self):
+        """Clears the entire current context."""
+        print("Clearing context.")
+        self.current_context = {}
+
+class DecisionEngine:
+    """
+    A component for making decisions or deriving insights based on ontology data and rules.
+    This is a complex area and these are placeholders for potential modules.
+    It might involve AI/ML models, rule engines, or voting mechanisms for collaborative decisions.
+    """
+    def __init__(self, knowledge_store: KnowledgeStore):
+        self.knowledge_store = knowledge_store
+        # Modules can be instantiated here
+        self.consensus_voting = self.ConsensusVoting(self)
+        self.chain_of_thought_voting = self.ChainOfThoughtVoting(self)
+        self.reasoning_layer = self.ReasoningLayer(self)
+        self.probability_map = self.ProbabilityMap(self)
+        self.expert_appeal = self.ExpertAppealMechanism(self)
+        print("DecisionEngine initialized.")
+
+    class ConsensusVoting:
+        """For decisions requiring agreement from multiple sources or agents."""
+        def __init__(self, engine):
+            self.engine = engine
+        def process_votes(self, topic, votes):
+            print(f"Processing consensus votes for topic: {topic}")
+            # Logic for tallying votes and determining consensus
+            return {"decision": "placeholder_consensus_decision"}
+
+    class ChainOfThoughtVoting:
+        """For decisions that benefit from transparent, step-by-step reasoning paths provided by voters."""
+        def __init__(self, engine):
+            self.engine = engine
+        def process_reasoned_votes(self, topic, reasoned_votes):
+            print(f"Processing chain-of-thought votes for topic: {topic}")
+            # Logic for evaluating reasoning paths and aggregating
+            return {"decision": "placeholder_cot_decision", "supporting_reasoning": []}
+
+    class ReasoningLayer:
+        """Applies logical rules (e.g., OWL, SWRL, custom rules) to infer new knowledge."""
+        def __init__(self, engine):
+            self.engine = engine
+        def infer(self, facts, rules):
+            print(f"Performing inference with {len(facts)} facts and {len(rules)} rules.")
+            # Placeholder for a rule engine or inference mechanism
+            return {"inferred_knowledge": []}
+
+    class ProbabilityMap:
+        """Manages probabilistic relationships or uncertainties within the ontology."""
+        def __init__(self, engine):
+            self.engine = engine
+        def update_probability(self, element_id, event, probability):
+            print(f"Updating probability for element {element_id} regarding event '{event}' to {probability}")
+            # Logic for Bayesian networks or probabilistic models
+
+    class ExpertAppealMechanism:
+        """Allows for human expert intervention or review in automated decisions."""
+        def __init__(self, engine):
+            self.engine = engine
+        def flag_for_expert_review(self, decision_id, reason):
+            print(f"Flagging decision {decision_id} for expert review: {reason}")
+            # Workflow for routing to experts
+
+class SemanticSearch:
+    """
+    Enables searching for ontology elements or related data based on meaning,
+    not just keywords. This often involves embeddings or graph traversal.
+    """
+    def __init__(self, knowledge_store: KnowledgeStore):
+        self.knowledge_store = knowledge_store
+        self.index = {} # Simplified index; could be an embedding store or graph index
+
+    def index_element(self, element: OntologyElement):
+        """
+        Indexes an ontology element for semantic search.
+        This might involve generating embeddings for its name and description.
+        """
+        print(f"Indexing element {element.name} for semantic search.")
+        # In a real system, generate vector embeddings here
+        self.index[element.id] = {
+            "name": element.name,
+            "description": element.description,
+            "type": element.__class__.__name__
+        }
+
+    def search_by_meaning(self, query_text, top_k=5):
+        """
+        Searches for elements whose meaning is similar to the query text.
+        Placeholder: Real implementation would use embedding similarity.
+        """
+        print(f"Performing semantic search for: '{query_text}'")
+        # Simple keyword matching for placeholder; real search would use vector similarity
+        results = []
+        for element_id, data in self.index.items():
+            if query_text.lower() in data["name"].lower() or query_text.lower() in data["description"].lower():
+                results.append(self.knowledge_store.get_element(element_id))
+                if len(results) == top_k:
+                    break
+        return results
+
+class MachineLearningGuidance:
+    """
+    Provides recommendations or guidance based on machine learning models
+    that might be trained on ontology usage, data patterns, etc.
+    """
+    def __init__(self, knowledge_store: KnowledgeStore):
+        self.knowledge_store = knowledge_store
+        # Potentially load or manage ML models here
+
+    def get_model_recommendations(self, context_data):
+        """
+        Suggests relevant models, concepts, or actions based on the current context.
+        """
+        print(f"Getting ML model recommendations for context: {context_data}")
+        # Placeholder: logic to interact with an ML model serving system
+        return {"recommendations": ["placeholder_model_A", "placeholder_concept_B"]}
+
+    def log_training_protocol(self, model_id, protocol_details):
+        """
+        Logs the training protocol used for an ML model relevant to the ontology.
+        """
+        print(f"Logging training protocol for model {model_id}: {protocol_details}")
+        # Store protocol for reproducibility and governance
+
+class FederatedLearningInfra:
+    """
+    Manages infrastructure for federated learning, where models are trained
+    across decentralized data sources (e.g., different domains in a data mesh)
+    without centrally collecting the data.
+    """
+    def __init__(self):
+        self.registered_nodes = {} # {node_id: node_info}
+        self.global_model_version = 0
+
+    def register_node(self, node_id, node_endpoint, available_data_info):
+        """Registers a data node (e.g., a domain's data store) for federated learning."""
+        if node_id not in self.registered_nodes:
+            self.registered_nodes[node_id] = {
+                "endpoint": node_endpoint,
+                "data_info": available_data_info,
+                "status": "active"
+            }
+            print(f"Federated Learning Node {node_id} registered from {node_endpoint}.")
+        else:
+            print(f"Node {node_id} already registered. Updating info.")
+            self.registered_nodes[node_id]["endpoint"] = node_endpoint # Update if needed
+            self.registered_nodes[node_id]["data_info"] = available_data_info
+
+
+    def distribute_model(self, model_architecture, model_parameters):
+        """Distributes a global model (architecture and parameters) to registered nodes."""
+        self.global_model_version += 1
+        print(f"Distributing global model version {self.global_model_version} to {len(self.registered_nodes)} nodes.")
+        # In a real system, this would involve sending the model to each node's endpoint.
+        for node_id in self.registered_nodes:
+            print(f"  - Sending model to node {node_id}")
+            # Simulating model distribution: node.receive_model(model_architecture, model_parameters)
+        return self.global_model_version
+
+    def aggregate_updates(self, local_updates):
+        """
+        Aggregates model updates received from participating nodes.
+        `local_updates` would be a list of model parameter updates from each node.
+        """
+        print(f"Aggregating updates from {len(local_updates)} nodes.")
+        # Placeholder: logic for federated averaging (e.g., FedAvg) or other aggregation strategies
+        # aggregated_parameters = perform_aggregation(local_updates)
+        # Update global model with aggregated_parameters
+        print("Global model updated with aggregated parameters.")
+        return {"status": "aggregation_complete", "new_global_version": self.global_model_version}
+
+class SampleDataRegistry:
+    """
+    Manages sample datasets and libraries that can be used for testing,
+    demonstration, or initial exploration within the ontology framework.
+    """
+    def __init__(self):
+        self.datasets = {} # {dataset_id: dataset_info}
+        self.libraries = {} # {library_id: library_info}
+
+    def register_dataset(self, dataset_id, name, description, source_url_or_path, data_format):
+        """Registers a sample dataset."""
+        if dataset_id not in self.datasets:
+            self.datasets[dataset_id] = {
+                "name": name,
+                "description": description,
+                "source": source_url_or_path,
+                "format": data_format,
+                "registered_at": datetime.utcnow()
+            }
+            print(f"Sample dataset '{name}' (ID: {dataset_id}) registered.")
+        else:
+            print(f"Dataset ID {dataset_id} already exists. Updating information.")
+            self.datasets[dataset_id].update({
+                "name": name, "description": description, "source": source_url_or_path, "format": data_format
+            })
+
+
+    def get_dataset(self, dataset_id):
+        """Retrieves information or loads a sample dataset."""
+        dataset_info = self.datasets.get(dataset_id)
+        if dataset_info:
+            print(f"Retrieving sample dataset '{dataset_info['name']}'. Source: {dataset_info['source']}")
+            # Placeholder: In a real system, this might load data into memory or provide a path
+            # For example, if it's a local CSV: pandas.read_csv(dataset_info['source'])
+            return dataset_info
+        else:
+            print(f"Dataset ID {dataset_id} not found.")
+            return None
+
+    def register_library(self, library_id, name, description, version, purpose):
+        """Registers a code library or tool relevant to the ontology or data mesh."""
+        self.libraries[library_id] = {
+            "name": name,
+            "description": description,
+            "version": version,
+            "purpose": purpose,
+            "registered_at": datetime.utcnow()
+        }
+        print(f"Library '{name}' (ID: {library_id}) version {version} registered.")
+
+    def get_library_info(self, library_id):
+        """Retrieves information about a registered library."""
+        return self.libraries.get(library_id)
+
+
+if __name__ == '__main__':
+    # Example Usage (Illustrative)
+    log = Logger()
+    log.log_event("FrameworkInit", "Ontology framework script started.", "INFO")
+
+    # Create a knowledge store
+    ks = KnowledgeStore()
+    db_connector = DatabaseConnector("CRM_DB", "postgresql://user:pass@host:port/crm", "PostgreSQL")
+    ks.register_connector(db_connector)
+
+    # Define some concepts
+    customer_concept = Concept("Customer", "Represents a customer of the business.")
+    product_concept = Concept("Product", "Represents a product sold by the business.")
+    ks.add_element(customer_concept)
+    ks.add_element(product_concept)
+    log.log_event("OntologySetup", f"Concept '{customer_concept.name}' created.", metadata={"id": customer_concept.id})
+
+
+    # Define a relationship
+    purchases_relationship = Relationship(
+        name="purchases",
+        description="Indicates that a customer has purchased a product.",
+        domain_concept=customer_concept,
+        range_concept_or_literal=product_concept
+    )
+    ks.add_element(purchases_relationship)
+    customer_concept.add_relationship(purchases_relationship)
+    product_concept.add_relationship(purchases_relationship) # Relationships can be bi-directionally navigable if needed
+
+    # Versioning example
+    vc = VersionControl()
+    customer_concept.update_description("An individual or organization that buys goods or services.")
+    customer_concept.version = "1.0.1"
+    vc.commit_changes(customer_concept, "Updated customer description for clarity.")
+
+    # Context example
+    ctx_manager = ContextManager()
+    ctx_manager.set_context("user_role", "OntologyManager")
+    ctx_manager.set_context("active_domain", "Sales")
+
+    # Decision Engine example
+    decision_engine = DecisionEngine(ks)
+    # Assume some voting data
+    votes_on_schema_change = [{"voter": "DomainA", "vote": "approve"}, {"voter": "DomainB", "vote": "reject"}]
+    decision_engine.consensus_voting.process_votes("SchemaChangeProposalX", votes_on_schema_change)
+
+    # Semantic Search Example
+    search_engine = SemanticSearch(ks)
+    search_engine.index_element(customer_concept)
+    search_engine.index_element(product_concept)
+    results = search_engine.search_by_meaning("business client")
+    print(f"Search results for 'business client': {results}")
+
+    # Data Product Example (Integrating with OntologyElement ideas)
+    sales_data_product = DataProduct(
+        name="SalesDataProduct",
+        domain="Sales", # Could be a Domain object or ID
+        description="Aggregated sales data for Q1."
+    )
+    # sales_data_product could also inherit from OntologyElement or be managed by KS
+    # For now, manually log its creation
+    log.log_event("DataProductCreation", f"Data Product '{sales_data_product.name}' defined.", metadata={"id": sales_data_product.id})
+    ks.add_element(sales_data_product) # If DataProduct is an OntologyElement
+
+    print("\nIllustrative run finished.")
+    log.log_event("FrameworkEnd", "Ontology framework script finished.", "INFO")
+
+    # To see logs:
+    # for entry in log.get_logs():
+    #     print(entry)


### PR DESCRIPTION
This commit introduces a new framework for a data mesh ontology. It lays the groundwork for a future state that includes capabilities for:
- Full data mesh enclosure
- Multiple databases, datalake, external web search, API access
- Shared context
- Ontology, knowledge base, knowledge graph, decision tree

The new framework is located in `ontology/data_mesh_ontology/framework.py` and includes initial Python classes and structures for:
- Core ontology elements (Concept, Relationship)
- Version control and logging
- Knowledge store management (for various data sources)
- Context management
- Decision engine components (voting, reasoning)
- Semantic search
- Machine learning guidance and federated learning infrastructure
- Sample data registry

Extensive comments have been added to outline the purpose and future development paths for these components.